### PR TITLE
Update dependebot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,13 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule: 
-      interval: "weekly"
+      interval: "monthly"
+    ignore:
+      # ignore patch updates to all cargo crates
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Includes
- ignoring patch updates
- monthly updates instead of weekly
- github-actions updates will also be tracked by dependebot