### PR TITLE
Bump `fbas_analyzer` to 0.7.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "rlib"]
 debug = true
 
 [dependencies]
-fbas_analyzer = { version = "0.7.1", default-features = false }
+fbas_analyzer = { version = "0.7.4", default-features = false }
 console_error_panic_hook = "0.1.1"
 web-sys = { version = "0.3", features = ['console']}
 serde_json = "1.0"


### PR DESCRIPTION
Mostly to consume an input parsing bugfix relevant for data from stellarbeat.